### PR TITLE
Have hbootmod.ko create /dev/hbootctrl

### DIFF
--- a/README
+++ b/README
@@ -21,7 +21,6 @@ Running 2nd-boot:
 SCRIPT:
 ====================================================================================
 insmod /system/etc/2nd-boot/hbootmod.ko [emu_uart=115200]
-mknod /dev/hbootctrl c `cat /proc/devices | grep hboot | awk '{print $1}' ` 0
 /system/etc/2nd-boot/hbootuser /system/etc/2nd-boot/hboot.cfg 
 ====================================================================================
 

--- a/hbootmod/hboot.c
+++ b/hbootmod/hboot.c
@@ -18,6 +18,7 @@
 #define CTRL_DEVNAME "hbootctrl"
 
 static int dev_major;
+static struct class *dev_class;
 
 /* NOTE: 0x00100000 is mapped per sector, keep that in mind */
 
@@ -307,6 +308,7 @@ static int hbootctrl_write(struct file *file, const char __user *buf, size_t cou
 int __init hbootmod_init(void) 
 {
 	int ret;
+	struct device *dev;
 
 	ret = buffers_init();
 	if (ret < 0) 
@@ -329,6 +331,15 @@ int __init hbootmod_init(void)
 		printk(KERN_WARNING CTRL_DEVNAME ": Failed to create dev\n");
 		unregister_chrdev(dev_major, CTRL_DEVNAME);
 		buffers_destroy();
+		return ret;
+	}
+
+	dev_class = class_create(THIS_MODULE, CTRL_DEVNAME);
+	dev = device_create(dev_class, NULL, MKDEV(dev_major,0), NULL, CTRL_DEVNAME);
+	if (IS_ERR(dev))
+	{
+		ret = PTR_ERR(dev);
+		printk(KERN_WARNING CTRL_DEVNAME ": Failed to create /dev/" CTRL_DEVNAME);
 		return ret;
 	}
 


### PR DESCRIPTION
With this patch mknod is not needed.
